### PR TITLE
Skip rules

### DIFF
--- a/src/hapInterrogation.py
+++ b/src/hapInterrogation.py
@@ -36,6 +36,10 @@ def get_args():
         help="Default duration rate to use for single event infections (default = 15 days)")
     p.add_argument('-b', '--burnin', default='2018-01-01', type=str,
         help="Date to begin considering new infections (YYYY-MM-DD)")
+    p.add_argument('-t', '--qpcr_threshold', default=0, type=float,
+        help="qpcr threshold to consider an infection true or false")
+    p.add_argument('-q', '--qpcr_flag', action='store_true',
+        help="use pcr of the date instead of the true false of the haplotype")
 
     # if no args given print help
     if len(sys.argv) == 1:
@@ -54,7 +58,7 @@ def main():
     meta = pd.read_stata(args.meta)
 
     # initialize modules
-    s = SeekDeepUtils()
+    s = SeekDeepUtils(date_qpcr=args.qpcr_flag, qpcr_threshold=args.qpcr_threshold)
 
     # calculate allele frequency
     if args.allele_frequency:

--- a/src/tripletModel.py
+++ b/src/tripletModel.py
@@ -152,9 +152,13 @@ class TripletModel:
         """
         if not self.likelihoods_created:
             # series {cohortid : [qpcr_triplet_matrix, age_triplet_matrix]}
+
+            ## Apply bootstrapping on this variable instead of on the MMS df
             qpcr_age = self.merged_meta_sdo.\
                 groupby('cohortid').\
                 apply(lambda x : self.__triplet_iter__(x))
+
+            sys.exit(qpcr_age)
 
             # assign triplets to likelihood types and save qpcr and age of each first triplet
             qpcr_age.apply(lambda x : self.__assign_triplets__(x))
@@ -181,7 +185,7 @@ class TripletModel:
 
         # return negative to minimize
         return -1 * log_lik.sum()
-    def AQ(self, method='Nelder-Mead', bootstrap=False):
+    def AQ(self, method='Nelder-Mead', bootstrap= False):
         if bootstrap:
             self.__bootstrap__()
 
@@ -262,10 +266,12 @@ def main():
 
     # # plot triplet sensitivity estimation by age as afunction of qpcr
     # triplet_by_age(sdo, meta)
-
+    print('loading data...')
     t = TripletModel(sdo, meta)
-    params = np.array([t.AQ() for _ in range(300)])
-    boot_params = np.array([t.AQ(bootstrap=True) for _ in range(300)])
+    print('Starting Triplets...')
+    t.AQ()
+    # params = np.array([t.AQ() for _ in range(300)])
+    # boot_params = np.array([t.AQ(bootstrap=True) for _ in range(300)])
 
     # params = np.array([t.AQ() for _ in range(100)])
     # params


### PR DESCRIPTION
Added two options 
- '-q' allows for calculating skips based off the qpcr value of the date instead of whether or not the haplotype was actually observed on that date
- '-t' allows for setting a minimum threshold on the qpcr value. any value below the threshold will still be counted as a skip regardless of whether or not the haplotype was seen. 