### PR TITLE
Seekdeep utils

### DIFF
--- a/src/hapInterrogation.py
+++ b/src/hapInterrogation.py
@@ -36,10 +36,10 @@ def get_args():
         help="Default duration rate to use for single event infections (default = 15 days)")
     p.add_argument('-b', '--burnin', default='2018-01-01', type=str,
         help="Date to begin considering new infections (YYYY-MM-DD)")
-    p.add_argument('-t', '--qpcr_threshold', default=0, type=float,
-        help="qpcr threshold to consider an infection true or false")
-    p.add_argument('-q', '--qpcr_flag', action='store_true',
-        help="use pcr of the date instead of the true false of the haplotype")
+    p.add_argument('-t', '--qpcr_threshold', default=0.1, type=float,
+        help="qpcr threshold to consider a sample (set to 0 for no threshold)")
+    p.add_argument('-q', '--fail_flag', action='store_false', default=True,
+        help="if no haplotypes are recovered and PCR is positive, drop sample (default=True, use flag to deactivate filter)")
 
     # if no args given print help
     if len(sys.argv) == 1:
@@ -61,7 +61,7 @@ def main():
     s = SeekDeepUtils(
         sdo = sdo,
         meta = meta,
-        date_qpcr=args.qpcr_flag,
+        fail_flag=args.fail_flag,
         qpcr_threshold=args.qpcr_threshold)
 
     # calculate allele frequency
@@ -85,20 +85,17 @@ def main():
     # calculate start and end of infections
     elif args.old_new_infections:
         onl = s.Old_New_Infection_Labels(
-            sdo, meta,
             allowedSkips = args.num_skips,
             default=args.default_duration,
             burnin=args.burnin)
         return print_out(onl)
 
     elif args.new_infections:
-        new_infections = s.New_Infections(
-            sdo, meta, allowedSkips=args.num_skips)
+        new_infections = s.New_Infections(allowedSkips=args.num_skips)
         return print_out(new_infections)
 
     elif args.force_of_infection:
         foi_params = s.Force_of_Infection(
-            sdo, meta,
             foi_method=args.force_of_infection,
             allowedSkips=args.num_skips,
             default=args.default_duration,

--- a/src/hapInterrogation.py
+++ b/src/hapInterrogation.py
@@ -58,7 +58,11 @@ def main():
     meta = pd.read_stata(args.meta)
 
     # initialize modules
-    s = SeekDeepUtils(date_qpcr=args.qpcr_flag, qpcr_threshold=args.qpcr_threshold)
+    s = SeekDeepUtils(
+        sdo = sdo,
+        meta = meta,
+        date_qpcr=args.qpcr_flag,
+        qpcr_threshold=args.qpcr_threshold)
 
     # calculate allele frequency
     if args.allele_frequency:

--- a/src/seekdeep_modules.py
+++ b/src/seekdeep_modules.py
@@ -342,29 +342,32 @@ class HaplotypeUtils:
 class SeekDeepUtils:
     """class for various utilities related to SeekDeep output"""
     pd.set_option('mode.chained_assignment', None) # remove settingwithcopywarning
-    def __init__(self, sdo, meta, date_qpcr=True, qpcr_threshold = 0):
+    def __init__(self, sdo, meta, fail_flag=True, qpcr_threshold = 0):
         self.sdo = sdo
         self.meta = meta
-        self.__prepare_pr2__()
-        sys.exit()
 
-        # boolean controlling whether to use qpcr fraction or not
-        self.date_qpcr = date_qpcr
-
-        # minimum threshold to use when calculating skips
+        # minimum threshold qpcr to consider a sample
         self.qpcr_threshold = qpcr_threshold
+        # boolean controlling whether to drop failed sequencing samples
+        self.fail_flag = fail_flag
+
+        self.__prepare_pr2__()
     def __prepare_pr2__(self):
         self.__prepare_sdo__()
         self.__prepare_meta__()
 
         # filter qpcr dates
-        self.meta = self.meta[(self.meta.qpcr == 0) | (self.meta.qpcr >= 0.1)]
+        if self.qpcr_threshold > 0:
+            self.meta = self.meta[(self.meta.qpcr == 0) | (self.meta.qpcr >= self.qpcr_threshold)]
 
         # merge meta and sdo
         self.pr2 = self.meta.merge(self.sdo, how='left')
 
         # filter all positive qpcr dates with failed sequencing
-        self.pr2 = self.pr2[~((self.pr2.qpcr > 0) & np.isnan(self.pr2.c_AveragedFrac))]
+        if self.fail_flag:
+            self.pr2 = self.pr2[~((self.pr2.qpcr > 0) & np.isnan(self.pr2.c_AveragedFrac))]
+
+        self.pr2['h_fraction'] = self.pr2.qpcr * self.pr2.c_AveragedFrac
     def __prepare_meta__(self):
         """prepare meta data for usage in timeline generation"""
         self.meta = self.meta[['date', 'cohortid', 'qpcr', 'agecat']]
@@ -429,20 +432,20 @@ class SeekDeepUtils:
             if timeline.empty:
                 continue
 
-                # find infection events and skips between them
-                timeline[['i_events', 'skips']] = timeline.apply(
-                lambda x : self.__calculate_skips__(x, diagnose=True),
-                axis = 1, result_type = 'expand')
+            # find infection events and skips between them
+            timeline[['i_events', 'skips']] = timeline.apply(
+            lambda x : self.__calculate_skips__(x, diagnose=True),
+            axis = 1, result_type = 'expand')
 
-                # for haplotype row create a dataframe of skips and dates
-                for _, row in timeline.iterrows():
-                    skip_dataframe.append(self.__arrange_skips__(row, cid))
+            # for haplotype row create a dataframe of skips and dates
+            for _, row in timeline.iterrows():
+                skip_dataframe.append(self.__arrange_skips__(row, cid))
 
-                    self.skip_df = pd.concat(skip_dataframe)
+        self.skip_df = pd.concat(skip_dataframe)
 
-                    self.skip_df.date = pd.to_datetime(self.skip_df.date)
+        self.skip_df.date = pd.to_datetime(self.skip_df.date)
 
-                    return self.skip_df
+        return self.skip_df
     def __prepare_new_infections__(self, cids, hids, new_ifx):
         """prepare new infections dataframe for downstream usage"""
 
@@ -511,40 +514,11 @@ class SeekDeepUtils:
         self.sdo['s_COI'] = self.sdo['new_COI'] + 1
         self.sdo.drop('new_COI', axis = 1, inplace = True)
     def __generate_timeline__(self, cohortid, boolArray=False):
-        """generate a longform timeline for a given cohortid"""
-        long_cid = self.meta[
-            self.meta.cohortid == cohortid
-        ].merge(
-            self.sdo[['date', 'cohortid', 'h_popUID', 'c_AveragedFrac']],
-            how = 'left'
-        )
-
-        # create haplotype qpcr fractions
-        long_cid['h_fraction'] = long_cid['c_AveragedFrac'] * long_cid['qpcr']
-
-        if self.date_qpcr:
-
-            qpcr_vals = long_cid[['date', 'qpcr']].drop_duplicates().qpcr.values
-
-            #pivot and transpose
-            wide_cid = long_cid.pivot(index='h_popUID', columns='date', values='qpcr').T
-
-            # replace all values with qpcr date values
-            for i in range(wide_cid.shape[1]):
-                try:
-                    first_inf = np.where(wide_cid.iloc[:,i] > 0)[0][0]
-                    wide_cid.iloc[:,i][first_inf:] = qpcr_vals[first_inf:]
-                except IndexError:
-                    pass
-
-            # transpose
-            wide_cid = wide_cid.T
-
-        else:
-            wide_cid = long_cid[['date', 'cohortid', 'h_popUID', 'h_fraction']].pivot(
-                index='h_popUID',
-                columns = 'date',
-                values = 'h_fraction')
+        """generate a wideform timeline for a given cohortid"""
+        wide_cid = self.pr2[self.pr2.cohortid == cohortid].pivot(
+            index = 'h_popUID',
+            columns = 'date',
+            values = 'h_fraction')
 
         wide_cid = wide_cid[~wide_cid.index.isna()]
 
@@ -555,7 +529,7 @@ class SeekDeepUtils:
             return wide_cid
     def __all_timelines__(self):
         """returns a dictionary of all timelines indexed by cohortid"""
-        return {cid : self.__generate_timeline__(cid, boolArray=True) for cid in self.sdo.cohortid.unique()}
+        return {cid : self.__generate_timeline__(cid, boolArray=True) for cid in self.pr2.cohortid.unique()}
     def __infection_labeller__(self, row, allowedSkips):
         """label infections as true or false"""
         # visits before burnin are false
@@ -923,7 +897,6 @@ class SeekDeepUtils:
         return self.sdo
     def Time_Independent_Allele_Frequency(self, sdo, controls=False):
         """calculates allele frequency of each haplotype in population with independent time"""
-        self.__prepare_sdo__(sdo, controls)
 
         # initialize dataframe to return
         a_freq = self.sdo[['h_popUID']].drop_duplicates()
@@ -942,16 +915,12 @@ class SeekDeepUtils:
             lambda x : x.h_Count / hapCountsTotal, axis = 1)
 
         return a_freq
-    def Haplotype_Skips(self, sdo, meta, controls=False):
+    def Haplotype_Skips(self, controls=False):
         """returns an array of the skips found per cid~haplotype across dates"""
-        self.__prepare_sdo__(sdo, controls)
-        self.__prepare_meta__(meta)
         self.__prepare_skips__()
         return self.skip_df
     def Duration_of_Infection(self, sdo, meta, controls=False, allowedSkips = 3, default=15):
         """calculates duration of infections for each cohortid ~ h_popUID"""
-        self.__prepare_sdo__(sdo)
-        self.__prepare_meta__(meta)
 
         # generate timelines for each cohortid~h_popUID
         timelines = {c : self.__generate_timeline__(c, boolArray=True) for c in self.sdo.cohortid.unique()}
@@ -975,12 +944,9 @@ class SeekDeepUtils:
         self.durations = self.__prepare_durations__(i_durations)
 
         return self.durations
-    def Old_New_Infection_Labels(self, sdo, meta, controls=False, allowedSkips = 3, default=15, burnin='2018-01-01'):
+    def Old_New_Infection_Labels(self, controls=False, allowedSkips = 3, default=15, burnin='2018-01-01'):
         """labels cid~hid infections that developed past a burn-in date as new else old"""
         self.burnin = pd.to_datetime(burnin)
-
-        self.__prepare_sdo__(sdo, controls)
-        self.__prepare_meta__(meta)
         self.__prepare_skips__()
         self.__label_new_infections__(allowedSkips)
 
@@ -990,28 +956,19 @@ class SeekDeepUtils:
             apply(lambda x : self.__label_haplotype_infection_type__(x))
 
         return hit_labels
-    def New_Infections(self, sdo, meta, controls=False, allowedSkips = 3, burnin='2018-01-01'):
+    def New_Infections(self, controls=False, allowedSkips = 3, burnin='2018-01-01'):
         """calculates number of new infections for each haplotype in each cohortid with allowed skips"""
         self.burnin = pd.to_datetime(burnin)
-
-        self.__prepare_sdo__(sdo, controls)
-        self.__prepare_meta__(meta)
         self.__prepare_skips__()
-
-
         self.__label_new_infections__(allowedSkips)
 
         return self.skip_df
-    def Force_of_Infection(self, sdo, meta, controls=False, foi_method = 'all', allowedSkips = 3, default=15, burnin = '2018-01-01'):
+    def Force_of_Infection(self, controls=False, foi_method = 'all', allowedSkips = 3, default=15, burnin = '2018-01-01'):
         """calculate force of infection for a dataset"""
         self.burnin = pd.to_datetime(burnin)
-
-        self.__prepare_sdo__(sdo)
-        self.__prepare_meta__(meta)
         self.__prepare_skips__()
         self.__label_new_infections__(allowedSkips)
         self.sdo = self.sdo.merge(self.skip_df, how='left')
-
 
         if foi_method == 'all':
             return self.__foi_method_all__()

--- a/src/seekdeep_modules.py
+++ b/src/seekdeep_modules.py
@@ -353,18 +353,18 @@ class SeekDeepUtils:
 
         # minimum threshold to use when calculating skips
         self.qpcr_threshold = qpcr_threshold
-
     def __prepare_pr2__(self):
-        def qpcr_filter(x):
-            print(x)
-            sys.exit()
-
         self.__prepare_sdo__()
         self.__prepare_meta__()
-        self.pr2 = self.meta.merge(self.sdo, how='left')
-        self.pr2.apply(lambda x : qpcr_filter(x), axis=1)
 
-        print(self.pr2)
+        # filter qpcr dates
+        self.meta = self.meta[(self.meta.qpcr == 0) | (self.meta.qpcr >= 0.1)]
+
+        # merge meta and sdo
+        self.pr2 = self.meta.merge(self.sdo, how='left')
+
+        # filter all positive qpcr dates with failed sequencing
+        self.pr2 = self.pr2[~((self.pr2.qpcr > 0) & np.isnan(self.pr2.c_AveragedFrac))]
     def __prepare_meta__(self):
         """prepare meta data for usage in timeline generation"""
         self.meta = self.meta[['date', 'cohortid', 'qpcr', 'agecat']]


### PR DESCRIPTION
Allow for correct qpcr filter : 
- drops samples where qpcr does not meet threshold 

Allow for failed sequencing :
- does not consider failed sequencing in skip analysis

Rewrote timeline code to allow for a single dataframe (pr2) instead of reading from sdo and meta at different stages. Changes in __prepare_skips__ and nested functions therein